### PR TITLE
fix some things in debug.rkt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # for Racket
 compiled/
+*~
 
 # for Mac OS X
 .DS_Store


### PR DESCRIPTION
This fixes the problem that `report` was evaluating the expression twice, meaning
```racket
(report (displayln "hi"))
```
Shows the output:
```
hi
(displayln hi) = #<void>
hi
```
This pull request fixes that and makes sure that the expression is evaluated only once.
`report-apply` also had that problem.

I also simplified the implementations of `report*`, `time-repeat*`, and `compare`, and made them more hygienic, so that they do not throw away so much lexical context and source location info.