### PR TITLE
#lang sugar/debug: use #^ instead of ^

### DIFF
--- a/sugar/debug.rkt
+++ b/sugar/debug.rkt
@@ -16,7 +16,7 @@
   
   (define (make-debug-readtable [rt (current-readtable)])
     (make-readtable rt
-                    #\^ 'non-terminating-macro report-proc))
+                    #\^ 'dispatch-macro report-proc))
 
   
   (define (wrap-reader reader)

--- a/sugar/test/debug-meta-lang.rkt
+++ b/sugar/test/debug-meta-lang.rkt
@@ -6,10 +6,10 @@
       [only-in "completely unexpected!"]
       [report "well, not really"])
   (parameterize ([current-error-port out])
-    ^5)
+    #^5)
   (check-equal? (get-output-string out) "5 = 5\n"))
 (let ([out (open-output-string)]
       [report/line "outta the blue!"])
   (parameterize ([current-error-port out])
-    ^^5)
+    #^^5)
   (check-equal? (get-output-string out) "5 = 5 on line 14\n"))


### PR DESCRIPTION
fixes https://github.com/mbutterick/sugar/issues/7