### PR TITLE
Allow #lang sugar/debug shorthands in other phases

### DIFF
--- a/sugar/debug.rkt
+++ b/sugar/debug.rkt
@@ -9,12 +9,22 @@
 
 
 (module reader racket/base
-  (require syntax/module-reader racket/syntax version/utils)  
+  (require (only-in syntax/module-reader make-meta-reader)
+           racket/syntax
+           version/utils
+           syntax/parse/define
+           (for-syntax racket/base racket/list))
   (provide (rename-out [debug-read read]
                        [debug-read-syntax read-syntax]
                        [debug-get-info get-info]))
 
   (define report-char #\R)
+
+  (define-simple-macro (require-a-lot require-spec)
+    #:with [i ...] (range -10 11)
+    (require (for-meta i require-spec) ...))
+
+  (require-a-lot racket/base)
   
   (define (make-debug-readtable [rt (current-readtable)])
     (make-readtable rt report-char 'dispatch-macro report-proc))

--- a/sugar/test/debug-meta-lang.rkt
+++ b/sugar/test/debug-meta-lang.rkt
@@ -1,5 +1,10 @@
 #lang sugar/debug racket
-(require rackunit)
+(require rackunit
+         (for-meta 1 (only-in racket/base begin-for-syntax))
+         (for-meta 2 (only-in racket/base begin-for-syntax))
+         (for-meta 3 (only-in racket/base let #%app open-output-string get-output-string parameterize
+                              current-error-port #%datum)
+                   rackunit))
 (let ([out (open-output-string)]
       [let "something else"]
       [local-require "something else entirely"]
@@ -12,4 +17,12 @@
       [report/line "outta the blue!"])
   (parameterize ([current-error-port out])
     #RR5)
-  (check-equal? (get-output-string out) "5 = 5 on line 14\n"))
+  (check-equal? (get-output-string out) "5 = 5 on line 19\n"))
+
+(begin-for-syntax
+  (begin-for-syntax
+    (begin-for-syntax
+      (let ([out (open-output-string)])
+        (parameterize ([current-error-port out])
+          #RR5)
+        (check-equal? (get-output-string out) "5 = 5 on line 27\n")))))


### PR DESCRIPTION
This allows for instance
```racket
#lang sugar/debug racket/base
(require (for-meta 1 (only-in racket/base begin-for-syntax))
         (for-meta 2 (only-in racket/base begin-for-syntax))
         (for-meta 3 (only-in racket/base #%datum)))
(begin-for-syntax
  (begin-for-syntax
    (begin-for-syntax
      #R5)))
```
To work properly.